### PR TITLE
Fixed wavetable name cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ and each can have a 14 character ASCII name.
 
 Download from the [releases](https://github.com/alvare/wave2blofeld/releases) page.
 
+Linux users can build from source (tested on Fedora).
+
 ## Usage
 
 ```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,7 +137,7 @@ int main(int argc, char* argv[]){
         }
 
         // wavetable name
-        for (int i = 0; i < 14; ++i){
+        for (int i = 0; i < opts.name.length(); ++i){
             mm[392+i] = opts.name[i] & 0x7f;
         }
 


### PR DESCRIPTION
Hi,

Cycle was get error if the length of waveform name  was less than 14 characters. Name validation code is in the begin of program, so in this point not necessary a fix length.

I builded this code in Linux, and working fine with it, so I added a Linux info to README.md.

Thank you!